### PR TITLE
Remove unitful u str workaround

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -3,15 +3,15 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
 deps = ["Libdl", "Pkg", "SHA", "Test"]
-git-tree-sha1 = "9930c1a6cd49d9fcd7218df6be417e6ae4f1468a"
+git-tree-sha1 = "055eb2690182ebc31087859c3dd8598371d3ef9e"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.2"
+version = "0.5.3"
 
 [[CategoricalArrays]]
-deps = ["Compat", "Future", "JSON", "Missings", "Printf", "Reexport"]
-git-tree-sha1 = "6362c49130b5888f5628bc197ee5f17aec7d2a88"
+deps = ["Compat", "Future", "Missings", "Printf", "Reexport", "Requires"]
+git-tree-sha1 = "94d16e77dfacc59f6d6c1361866906dbb65b6f6b"
 uuid = "324d7699-5711-5eae-9e2f-1d82baa6b597"
-version = "0.4.0"
+version = "0.5.2"
 
 [[CodecZlib]]
 deps = ["BinaryProvider", "Libdl", "Test", "TranscodingStreams"]
@@ -27,9 +27,9 @@ version = "1.4.0"
 
 [[DataFrames]]
 deps = ["CategoricalArrays", "CodecZlib", "Compat", "DataStreams", "Dates", "InteractiveUtils", "IteratorInterfaceExtensions", "LinearAlgebra", "Missings", "Printf", "Random", "Reexport", "SortingAlgorithms", "Statistics", "StatsBase", "TableTraits", "Tables", "Test", "TranscodingStreams", "Unicode", "WeakRefStrings"]
-git-tree-sha1 = "ad34fefb72b18a8dd5c17fab9089d11111b61935"
+git-tree-sha1 = "7e032a76f3455e38660ac456791951ac2d0b1e70"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "0.14.1"
+version = "0.16.0"
 
 [[DataStreams]]
 deps = ["Dates", "Missings", "Test", "WeakRefStrings"]
@@ -39,9 +39,9 @@ version = "0.4.1"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
-git-tree-sha1 = "8fc6e166e24fda04b2b648d4260cdad241788c54"
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.14.0"
+version = "0.15.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -53,9 +53,9 @@ uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[DiffEqBase]]
 deps = ["Compat", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "RecursiveArrayTools", "Requires", "Roots", "SparseArrays", "StaticArrays", "Statistics", "SuiteSparse", "TableTraits", "Test", "TreeViews"]
-git-tree-sha1 = "a79e0d74bdc91d4dfc501fe03af762b48cbc3764"
+git-tree-sha1 = "9b077135e38482dcf74daf2406b9da4dc4dcb0ca"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "4.31.0"
+version = "4.31.2"
 
 [[Distributed]]
 deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
@@ -77,9 +77,9 @@ version = "0.1.1"
 
 [[JSON]]
 deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
-git-tree-sha1 = "fec8e4d433072731466d37ed0061b3ba7f70eeb9"
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.19.0"
+version = "0.20.0"
 
 [[LibGit2]]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -109,9 +109,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[ModiaMath]]
 deps = ["DataFrames", "DataStructures", "LinearAlgebra", "Pkg", "Printf", "Requires", "StaticArrays", "Sundials", "Test", "Unitful"]
-git-tree-sha1 = "82cebde6d94c25cee42ce6e96a02d62972aa6683"
+git-tree-sha1 = "b16363c5ff7782aa3fb57522351634d664177f2d"
 uuid = "67ccffd1-116d-535b-ad39-76a8fd0cbf71"
-version = "0.2.5"
+version = "0.3.0"
 
 [[OrderedCollections]]
 deps = ["Random", "Serialization", "Test"]
@@ -143,9 +143,9 @@ version = "0.6.0"
 
 [[RecursiveArrayTools]]
 deps = ["RecipesBase", "Requires", "StaticArrays", "Statistics", "Test"]
-git-tree-sha1 = "5ac1ea7d018bec90b0be614a9a37d1fd80dce8d9"
+git-tree-sha1 = "152afd0272d2f468c9f564d6f64cc3c10a8c1e94"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "0.18.4"
+version = "0.18.5"
 
 [[Reexport]]
 deps = ["Pkg"]
@@ -161,9 +161,9 @@ version = "0.5.2"
 
 [[Roots]]
 deps = ["Compat", "Printf"]
-git-tree-sha1 = "9a66815d2530705097a5668efa8b88aa238ada47"
+git-tree-sha1 = "2e7171b6f3b58b81201ba37d9e1220aff6d904a1"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "0.7.3"
+version = "0.7.4"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -190,19 +190,19 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[StaticArrays]]
 deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "ebc5c2a27d91d5ec611a9861168182e2168effd3"
+git-tree-sha1 = "1eb114d6e23a817cd3e99abc3226190876d7c898"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.9.2"
+version = "0.10.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsBase]]
-deps = ["DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
-git-tree-sha1 = "723193a13e8078cec6dcd0b8fe245c8bfd81690e"
+deps = ["DataStructures", "DelimitedFiles", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "Test"]
+git-tree-sha1 = "7b596062316c7d846b67bf625d5963a832528598"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.25.0"
+version = "0.27.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "SparseArrays"]
@@ -216,15 +216,15 @@ version = "2.6.0"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions", "Test"]
-git-tree-sha1 = "da062a2c31f16178f68190243c24140801720a43"
+git-tree-sha1 = "eba4b1d0a82bdd773307d652c6e5f8c82104c676"
 uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
-version = "0.4.0"
+version = "0.4.1"
 
 [[Tables]]
-deps = ["Requires", "Test"]
-git-tree-sha1 = "c7fb447deab835fa70ce6717e78c68b0f466a42c"
+deps = ["IteratorInterfaceExtensions", "Requires", "TableTraits", "Test"]
+git-tree-sha1 = "89f8fde6394579580fb75088e45ad95551199c7c"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "0.1.11"
+version = "0.1.14"
 
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
@@ -251,9 +251,9 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [[Unitful]]
 deps = ["LinearAlgebra", "Random", "Test"]
-git-tree-sha1 = "cef7da6d4e9735fae7c11cd28e77b76fd87db468"
+git-tree-sha1 = "ba654182cad07cd6c1f3ae969475e556db3283ea"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "0.12.0"
+version = "0.14.0"
 
 [[WeakRefStrings]]
 deps = ["Missings", "Random", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,6 +2,6 @@ julia 1.0
 DataFrames
 DataStructures
 JSON
-ModiaMath
+ModiaMath 0.3.0
 StaticArrays
 Unitful

--- a/src/Media/SimpleIdealGasMedium.jl
+++ b/src/Media/SimpleIdealGasMedium.jl
@@ -143,14 +143,14 @@ function standardCharacteristics(m::SimpleIdealGasMedium)::Dict{AbstractString,A
     end       
 
     mediumDict = Dict{AbstractString,Any}()
-    mediumDict["T"]  = uconvert.(u"°C", T*1U"K")
-    mediumDict["h"]  = h*1U"J/kg"
-    mediumDict["u"]  = u*1U"J/kg"
-    mediumDict["cp"] = cp*1U"J/(kg*K)"
-    mediumDict["cv"] = cv*1U"J/(kg*K)"
-    mediumDict["d(p=0.5 bar)"] = d[:,1]*1U"g/cm^3"
-    mediumDict["d(p=1.0 bar)"] = d[:,2]*1U"g/cm^3"
-    mediumDict["d(p=2.0 bar)"] = d[:,3]*1U"g/cm^3"
+    mediumDict["T"]  = uconvert.(u"°C", T*1u"K")
+    mediumDict["h"]  = h*1u"J/kg"
+    mediumDict["u"]  = u*1u"J/kg"
+    mediumDict["cp"] = cp*1u"J/(kg*K)"
+    mediumDict["cv"] = cv*1u"J/(kg*K)"
+    mediumDict["d(p=0.5 bar)"] = d[:,1]*1u"g/cm^3"
+    mediumDict["d(p=1.0 bar)"] = d[:,2]*1u"g/cm^3"
+    mediumDict["d(p=2.0 bar)"] = d[:,3]*1u"g/cm^3"
     return mediumDict
 end
 

--- a/src/Media/SimpleMedium.jl
+++ b/src/Media/SimpleMedium.jl
@@ -116,7 +116,7 @@ function standardCharacteristics(m::SimpleMedium)::Dict{AbstractString,Any}
 
     mediumDict = Dict{AbstractString,Any}()
     mediumDict["T"] = uconvert.(u"°C", T*1u"K")
-    mediumDict["h"] = h*U"J/kg"
+    mediumDict["h"] = h*u"J/kg"
 
     return mediumDict
 end

--- a/src/Media/SingleGasNasa.jl
+++ b/src/Media/SingleGasNasa.jl
@@ -204,13 +204,13 @@ function standardCharacteristics(m::SingleGasNasa)::Dict{AbstractString,Any}
     end       
 
     mediumDict = Dict{AbstractString,Any}()
-    mediumDict["T"]  = uconvert.(u"°C", T*1U"K")
-    mediumDict["h"]  = h*1U"J/kg"
-    mediumDict["u"]  = u*1U"J/kg"
-    mediumDict["cp"] = cp*1U"J/(kg*K)"
-    mediumDict["d(p=0.5 bar)"] = d[:,1]*1U"g/cm^3"
-    mediumDict["d(p=1.0 bar)"] = d[:,2]*1U"g/cm^3"
-    mediumDict["d(p=2.0 bar)"] = d[:,3]*1U"g/cm^3"
+    mediumDict["T"]  = uconvert.(u"°C", T*1u"K")
+    mediumDict["h"]  = h*1u"J/kg"
+    mediumDict["u"]  = u*1u"J/kg"
+    mediumDict["cp"] = cp*1u"J/(kg*K)"
+    mediumDict["d(p=0.5 bar)"] = d[:,1]*1u"g/cm^3"
+    mediumDict["d(p=1.0 bar)"] = d[:,2]*1u"g/cm^3"
+    mediumDict["d(p=2.0 bar)"] = d[:,3]*1u"g/cm^3"
     return mediumDict
 end
 

--- a/src/ModiaMedia.jl
+++ b/src/ModiaMedia.jl
@@ -12,17 +12,17 @@ such as multiple dispatch.
 This package is currently under development.
 """
 module ModiaMedia
-  
+
 const path    = dirname(dirname(@__FILE__))          # Absolute path of package directory
-const Version = "0.1.0-dev from 2018-11-18 10:15"
+const Version = "0.1.0-dev from 2019-01-09 17:48"
 
 println(" \nImporting ModiaMedia version ", Version)
 
- 
+
 export AbstractMedium, PureSubstance, getMedium
 export IdealMoistAir, SimpleMedium, SimpleIdealGasMedium, SingleGasNasa
 
-export density, density_der_1, density_pT, density_pT_der_1, density_pT_der_2, density_pT_der_3 
+export density, density_der_1, density_pT, density_pT_der_1, density_pT_der_2, density_pT_der_3
 export specificInternalEnergy_T, specificInternalEnergy_T_der_1, specificInternalEnergy_T_der_2
 
 export temperature, temperature_ph
@@ -51,7 +51,7 @@ abstract type MixtureMedium <: AbstractMedium end
 
 "`abstract type CondensingGases <: AbstractMedium` - Abstract type of all media consisting of condensing media"
 abstract type CondensingGases <: MixtureMedium end
- 
+
 "`abstract type ThermodynamicState` - Abstract type of all media states"
 abstract type ThermodynamicState end
 
@@ -69,7 +69,7 @@ using  Unitful
 import ModiaMath
 import Serialization
 
- 
+
 ### Including files for the ModiaMedia module --------------------------------------------------------
 include("Interfaces/PartialMedium.jl")
 include("Interfaces/PartialPureSubstance.jl")
@@ -88,13 +88,13 @@ function loadMediumDict(file::AbstractString)
                 "    ", file)
 
         try
-            f = open(file)  
+            f = open(file)
             mediumDict = Serialization.deserialize(f)
             close(f)
         catch
             error("\n\nFile \"", file, "\" is not compatible to the modified ModiaMedia source.\n",
                   "You have to delete this file and run `include(\"\$(ModiaMedia.path)/dict/GenerateMediumDict.jl\")` to regenerate it.\n")
-        end 
+        end
 
     else
         println("\n... File ", file, " does not exist.\n",
@@ -108,7 +108,7 @@ const mediumDictFile = "$path/src/Media/media.julia_serializer"
 const mediumDict     = loadMediumDict(mediumDictFile)
 
 include("Media/IdealMoistAir.jl")
- 
+
 ### Inquire medium
 getMedium(name::AbstractString) = mediumDict[name]
 

--- a/src/ModiaMedia.jl
+++ b/src/ModiaMedia.jl
@@ -71,9 +71,6 @@ import Serialization
 
  
 ### Including files for the ModiaMedia module --------------------------------------------------------
-include("Interfaces/Unitful_U_str.jl")   # only temporarily until the u".." issue is fixed in Unitful
-using  .Unitful_U_str
-
 include("Interfaces/PartialMedium.jl")
 include("Interfaces/PartialPureSubstance.jl")
 include("Interfaces/PartialMixtureMedium.jl")


### PR DESCRIPTION
Newest Unitful (0.14.0) does no longer require a workaround for u_str. Therefore, workaround is removed